### PR TITLE
Fix include ordering broken by alphabetization

### DIFF
--- a/include/mirage/persistent_kernel/tasks/mi300/paged_attention_ck_fmha_split_kv_mi300.cuh
+++ b/include/mirage/persistent_kernel/tasks/mi300/paged_attention_ck_fmha_split_kv_mi300.cuh
@@ -16,16 +16,19 @@
 #pragma once
 
 // CK FMHA Split-KV pipeline includes
+// NOTE: include order matters. tile_fmha_traits.hpp pulls in
+// block_attention_quant_scale_enum.hpp, which the splitkv pipeline headers
+// below require but do not include themselves. Do not alphabetize this block.
 #include "ck_tile/core.hpp"
-#include "ck_tile/ops/epilogue/default_2d_epilogue.hpp"
+#include "ck_tile/ops/fmha/pipeline/tile_fmha_shape.hpp"
+#include "ck_tile/ops/fmha/pipeline/tile_fmha_traits.hpp"
+#include "ck_tile/ops/fmha/pipeline/block_fmha_pipeline_problem.hpp"
+#include "ck_tile/ops/fmha/pipeline/block_fmha_fwd_splitkv_pipeline_qr_ks_vs.hpp"
 #include "ck_tile/ops/fmha/block/block_masking.hpp"
 #include "ck_tile/ops/fmha/block/block_position_encoding.hpp"
 #include "ck_tile/ops/fmha/block/page_block_navigator.hpp"
 #include "ck_tile/ops/fmha/block/variants.hpp"
-#include "ck_tile/ops/fmha/pipeline/block_fmha_fwd_splitkv_pipeline_qr_ks_vs.hpp"
-#include "ck_tile/ops/fmha/pipeline/block_fmha_pipeline_problem.hpp"
-#include "ck_tile/ops/fmha/pipeline/tile_fmha_shape.hpp"
-#include "ck_tile/ops/fmha/pipeline/tile_fmha_traits.hpp"
+#include "ck_tile/ops/epilogue/default_2d_epilogue.hpp"
 
 #ifndef CK_TILE_FMHA_FWD_FAST_EXP2
 #define CK_TILE_FMHA_FWD_FAST_EXP2 1

--- a/include/mirage/persistent_kernel/tasks/mi300/task_header.cuh
+++ b/include/mirage/persistent_kernel/tasks/mi300/task_header.cuh
@@ -14,6 +14,11 @@
  */
 
 // MI300 task implementations - clean AMD-only code, no NVIDIA ifdefs
+//
+// NOTE: the include order below is load-bearing. Several task headers rely on
+// types and helpers defined by earlier ones rather than including them
+// directly (e.g. attention_sink_mi300.cuh needs bf16/__hip_bfloat16,
+// kv_cache_update_mi300.cuh needs vec_load_8/vec_store_8). Do not alphabetize.
 
 // Generic tasks reused from ampere/ (platform-independent)
 #include "tasks/ampere/embedding.cuh"
@@ -21,31 +26,31 @@
 #include "tasks/ampere/reduction.cuh"
 
 // MI300-specific task implementations
+#include "tasks/mi300/rmsnorm_mi300.cuh"
 #include "tasks/mi300/argmax_mi300.cuh"
-#include "tasks/mi300/attention_sink_mi300.cuh"
-#include "tasks/mi300/gang_rmsnorm_linear_bias_mi300.cuh"
-#include "tasks/mi300/kv_cache_update_mi300.cuh"
+#include "tasks/mi300/rotary_embedding_mi300.cuh"
+#include "tasks/mi300/silu_mul_mi300.cuh"
+#include "tasks/mi300/silu_mul_linear_mi300.cuh"
 #include "tasks/mi300/linear_mi300.cuh"
+#include "tasks/mi300/gang_rmsnorm_linear_bias_mi300.cuh"
 #include "tasks/mi300/multitoken_paged_attention_mi300.cuh"
 #include "tasks/mi300/multitoken_paged_attention_split_kv_mi300.cuh"
-#include "tasks/mi300/rmsnorm_mi300.cuh"
-#include "tasks/mi300/rotary_embedding_mi300.cuh"
-#include "tasks/mi300/silu_mul_linear_mi300.cuh"
-#include "tasks/mi300/silu_mul_mi300.cuh"
+#include "tasks/mi300/kv_cache_update_mi300.cuh"
+#include "tasks/mi300/attention_sink_mi300.cuh"
 #ifdef MPK_USE_CK_FMHA
-#include "tasks/mi300/gang_attention_mi300.cuh"
-#include "tasks/mi300/paged_attention_ck_fmha_split_kv_mi300.cuh"
 #include "tasks/mi300/paged_attention_decode_minimal_hd64_mi300.cuh"
+#include "tasks/mi300/paged_attention_ck_fmha_split_kv_mi300.cuh"
+#include "tasks/mi300/gang_attention_mi300.cuh"
 #endif
 // MoE task implementations for MI300/MI350
+#include "tasks/mi300/moe_linear_mi300.cuh"
+#include "tasks/mi300/moe_linear_mxfp4_mi300.cuh"
+#include "tasks/mi300/moe_linear_mxfp4_ck_mi300.cuh"
 #include "tasks/mi300/gang_moe_linear_mi300.cuh"
 #include "tasks/mi300/gang_moe_linear_mxfp4_mi300.cuh"
 #include "tasks/mi300/gang_moe_pipelined_mxfp4_mi300.cuh"
-#include "tasks/mi300/gang_rmsnorm_linear_mxfp4_bias_argmax_mi300.cuh"
 #include "tasks/mi300/gang_rmsnorm_linear_mxfp4_bias_mi300.cuh"
-#include "tasks/mi300/moe_linear_mi300.cuh"
-#include "tasks/mi300/moe_linear_mxfp4_ck_mi300.cuh"
-#include "tasks/mi300/moe_linear_mxfp4_mi300.cuh"
+#include "tasks/mi300/gang_rmsnorm_linear_mxfp4_bias_argmax_mi300.cuh"
 #ifdef MPK_USE_CK_FMHA
 #include "tasks/mi300/gang_qkv_attn_fused_mi300.cuh"
 #endif
@@ -55,13 +60,12 @@
 #include "tasks/mi300/gang_oproj_topk_moe_fused_mi300.cuh"
 // Merge kernel needed by gang_full_layer_fused before it's included
 #include "tasks/ampere/merge_splitkv.cuh"
-#include "tasks/mi300/bias_add_mi300.cuh"
 #include "tasks/mi300/gang_full_layer_fused_mi300.cuh"
 #include "tasks/mi300/gang_full_layer_with_lmhead_fused_mi300.cuh"
 #include "tasks/mi300/gang_moe_swiglu_w2_mxfp4_mi300.cuh"
+#include "tasks/mi300/moe_topk_softmax_mi300.cuh"
 #include "tasks/mi300/moe_mul_sum_add_mi300.cuh"
 #include "tasks/mi300/moe_residual_add_f32_mi300.cuh"
-#include "tasks/mi300/moe_topk_softmax_mi300.cuh"
 #include "tasks/mi300/swigluoai_mi300.cuh"
-// Merge kernel moved above gang_full_layer_fused_mi300.cuh (needs it at
-// template definition time)
+#include "tasks/mi300/bias_add_mi300.cuh"
+// Merge kernel moved above gang_full_layer_fused_mi300.cuh (needs it at template definition time)


### PR DESCRIPTION
The GPT-OSS 120B megakernel failed to JIT-compile from a clean clone with 23 errors. Two include blocks had been alphabetized, which broke ordering dependencies that the headers rely on but do not declare:

  * task_header.cuh: attention_sink_mi300.cuh was sorted ahead of the headers defining bf16/__hip_bfloat16, and kv_cache_update_mi300.cuh ahead of those defining vec_load_8/vec_store_8.

  * paged_attention_ck_fmha_split_kv_mi300.cuh: tile_fmha_traits.hpp was sorted after block_fmha_fwd_splitkv_pipeline_qr_ks_vs.hpp. The traits header is what pulls in block_attention_quant_scale_enum.hpp, which the pipeline headers need but do not include themselves.

The include sets are unchanged -- only the order is restored. Added comments to both blocks so they are not re-sorted.

Verified on gfx950 (MI350) with GPT-OSS 120B, bs=1, USE_FP8_ACT=1: compiles with 0 errors, decode 2.173 ms/iter, coherent output.

**Description of changes:**



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


